### PR TITLE
Fix: Load script with anonymous crossorigin

### DIFF
--- a/script/bcarBetaLoader.user.js
+++ b/script/bcarBetaLoader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name BCAR Beta Loader
 // @namespace https://www.bondageprojects.com/
-// @version 0.4.0
+// @version 0.4.1
 // @description BCAR Bondacge Club Auto React
 // @author DrBranestawm
 // @match https://bondageprojects.elementfx.com/*

--- a/script/bcarBetaLoader.user.js
+++ b/script/bcarBetaLoader.user.js
@@ -16,6 +16,7 @@
 (function() {
     'use strict';
     var script = document.createElement("script");
+    script.setAttribute("crossorigin", "anonymous");
     script.src = "https://drbranestawm.github.io/BCAR/script/bcarBeta.js";
     document.head.appendChild(script);
 })();

--- a/script/bcarLoader.user.js
+++ b/script/bcarLoader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name BCAR Loader
 // @namespace https://www.bondageprojects.com/
-// @version 0.3.0
+// @version 0.3.1
 // @description BCAR Bondacge Club Auto React
 // @author DrBranestawm
 // @match https://bondageprojects.elementfx.com/*

--- a/script/bcarLoader.user.js
+++ b/script/bcarLoader.user.js
@@ -16,6 +16,7 @@
 (function() {
     'use strict';
     var script = document.createElement("script");
+    script.setAttribute("crossorigin", "anonymous");
     script.src = "https://drbranestawm.github.io/BCAR/script/bcar.js";
     document.head.appendChild(script);
 })();


### PR DESCRIPTION
Adds a `crossorigin="anonymous"` attribute to `<script>` tags, which will allow error reports to be collected from inside the mod, instead of displaying `Script Error.`