### PR TITLE
Fix loading on new accounts

### DIFF
--- a/script/bcar.js
+++ b/script/bcar.js
@@ -1281,7 +1281,7 @@ async function bcarSettingsRemove() {
 
     function migrate_gender() {
         const gd = Player.BCAR.bcarSettings.genderDefault
-        if (gd.pronoun || gd.intensive || gd.possessive) {
+        if (gd && (gd.pronoun || gd.intensive || gd.possessive)) {
             CommandGenderToggle([gd.gender.toLowerCase()]); // this will set correct values, deletes will delete old values
             delete gd.pronoun; // this deletes Player.BCAR.bcarSettings.genderDefault.pronoun
             delete gd.intensive;

--- a/script/bcarBeta.js
+++ b/script/bcarBeta.js
@@ -1281,7 +1281,7 @@ async function bcarSettingsRemove() {
 
     function migrate_gender() {
         const gd = Player.BCAR.bcarSettings.genderDefault
-        if (gd.pronoun || gd.intensive || gd.possessive) {
+        if (gd && (gd.pronoun || gd.intensive || gd.possessive)) {
             CommandGenderToggle([gd.gender.toLowerCase()]); // this will set correct values, deletes will delete old values
             delete gd.pronoun; // this deletes Player.BCAR.bcarSettings.genderDefault.pronoun
             delete gd.intensive;


### PR DESCRIPTION
It crashed during loading on new accounts because the settings were blank and so had no genderDefault so the mod didn't load for people who'd never used it before.

This just checks that genderDefault is defined. Another fix would be to call migrate_gender() after the default settings had been saved, if you'd prefer that.