### PR TITLE
Enable TypeScript support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+
+root = true
+
+[*.{js,d.ts}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,132 @@
+{
+  "name": "BCAR",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "bc-stubs": "^102.0.0-Beta.2",
+        "bondage-club-mod-sdk": "^1.1.0"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow=="
+    },
+    "node_modules/bc-stubs": {
+      "version": "102.0.0-Beta.2",
+      "resolved": "https://registry.npmjs.org/bc-stubs/-/bc-stubs-102.0.0-Beta.2.tgz",
+      "integrity": "sha512-MuKwTjQOUXjqqRq1IWE8i1Al3vdDqSGSZlP3HlC7JbGH72umLnCCEfars7IpaG4ij/MvEp4qU81apnCqG2JaDw==",
+      "dependencies": {
+        "@types/lz-string": "1.3.34",
+        "socket.io-client": "4.6.1"
+      }
+    },
+    "node_modules/bondage-club-mod-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bondage-club-mod-sdk/-/bondage-club-mod-sdk-1.1.0.tgz",
+      "integrity": "sha512-q+bmQejD1aQI9hkOqGbD8B562QsjA6YicGb3WVwYR8sN9/U9plwG5F0fjmS9BB5VFi2UYqAb4bSeCKC0r6LKBA=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "bc-stubs": "^102.0.0-Beta.2",
+    "bondage-club-mod-sdk": "^1.1.0"
+  }
+}

--- a/script/bcarBeta.js
+++ b/script/bcarBeta.js
@@ -24,6 +24,7 @@ if (window.BCAR_VERSION) {
 }
 // SDK stuff
 
+// @ts-expect-error
 var bcModSDK=function(){"use strict";const e="1.1.0";function o(e){alert("Mod ERROR:\n"+e);const o=new Error(e);throw console.error(o),o}const t=new TextEncoder;function n(e){return!!e&&"object"==typeof e&&!Array.isArray(e)}function r(e){const o=new Set;return e.filter((e=>!o.has(e)&&o.add(e)))}const i=new Map,a=new Set;function d(e){a.has(e)||(a.add(e),console.warn(e))}function s(e){const o=[],t=new Map,n=new Set;for(const r of p.values()){const i=r.patching.get(e.name);if(i){o.push(...i.hooks);for(const[o,a]of i.patches.entries())t.has(o)&&t.get(o)!==a&&d(`ModSDK: Mod '${r.name}' is patching function ${e.name} with same pattern that is already applied by different mod, but with different pattern:\nPattern:\n${o}\nPatch1:\n${t.get(o)||""}\nPatch2:\n${a}`),t.set(o,a),n.add(r.name)}}o.sort(((e,o)=>o.priority-e.priority));const r=function(e,o){if(0===o.size)return e;let t=e.toString().replaceAll("\r\n","\n");for(const[n,r]of o.entries())t.includes(n)||d(`ModSDK: Patching ${e.name}: Patch ${n} not applied`),t=t.replaceAll(n,r);return(0,eval)(`(${t})`)}(e.original,t);let i=function(o){var t,i;const a=null===(i=(t=m.errorReporterHooks).hookChainExit)||void 0===i?void 0:i.call(t,e.name,n),d=r.apply(this,o);return null==a||a(),d};for(let t=o.length-1;t>=0;t--){const n=o[t],r=i;i=function(o){var t,i;const a=null===(i=(t=m.errorReporterHooks).hookEnter)||void 0===i?void 0:i.call(t,e.name,n.mod),d=n.hook.apply(this,[o,e=>{if(1!==arguments.length||!Array.isArray(o))throw new Error(`Mod ${n.mod} failed to call next hook: Expected args to be array, got ${typeof e}`);return r.call(this,e)}]);return null==a||a(),d}}return{hooks:o,patches:t,patchesSources:n,enter:i,final:r}}function c(e,o=!1){let r=i.get(e);if(r)o&&(r.precomputed=s(r));else{let o=window;const a=e.split(".");for(let t=0;t<a.length-1;t++)if(o=o[a[t]],!n(o))throw new Error(`ModSDK: Function ${e} to be patched not found; ${a.slice(0,t+1).join(".")} is not object`);const d=o[a[a.length-1]];if("function"!=typeof d)throw new Error(`ModSDK: Function ${e} to be patched not found`);const c=function(e){let o=-1;for(const n of t.encode(e)){let e=255&(o^n);for(let o=0;o<8;o++)e=1&e?-306674912^e>>>1:e>>>1;o=o>>>8^e}return((-1^o)>>>0).toString(16).padStart(8,"0").toUpperCase()}(d.toString().replaceAll("\r\n","\n")),l={name:e,original:d,originalHash:c};r=Object.assign(Object.assign({},l),{precomputed:s(l),router:()=>{},context:o,contextProperty:a[a.length-1]}),r.router=function(e){return function(...o){return e.precomputed.enter.apply(this,[o])}}(r),i.set(e,r),o[r.contextProperty]=r.router}return r}function l(){const e=new Set;for(const o of p.values())for(const t of o.patching.keys())e.add(t);for(const o of i.keys())e.add(o);for(const o of e)c(o,!0)}function f(){const e=new Map;for(const[o,t]of i)e.set(o,{name:o,original:t.original,originalHash:t.originalHash,sdkEntrypoint:t.router,currentEntrypoint:t.context[t.contextProperty],hookedByMods:r(t.precomputed.hooks.map((e=>e.mod))),patchedByMods:Array.from(t.precomputed.patchesSources)});return e}const p=new Map;function u(e){p.get(e.name)!==e&&o(`Failed to unload mod '${e.name}': Not registered`),p.delete(e.name),e.loaded=!1,l()}function g(e,t,r){"string"==typeof e&&"string"==typeof t&&(alert(`Mod SDK warning: Mod '${e}' is registering in a deprecated way.\nIt will work for now, but please inform author to update.`),e={name:e,fullName:e,version:t},t={allowReplace:!0===r}),e&&"object"==typeof e||o("Failed to register mod: Expected info object, got "+typeof e),"string"==typeof e.name&&e.name||o("Failed to register mod: Expected name to be non-empty string, got "+typeof e.name);let i=`'${e.name}'`;"string"==typeof e.fullName&&e.fullName||o(`Failed to register mod ${i}: Expected fullName to be non-empty string, got ${typeof e.fullName}`),i=`'${e.fullName} (${e.name})'`,"string"!=typeof e.version&&o(`Failed to register mod ${i}: Expected version to be string, got ${typeof e.version}`),e.repository||(e.repository=void 0),void 0!==e.repository&&"string"!=typeof e.repository&&o(`Failed to register mod ${i}: Expected repository to be undefined or string, got ${typeof e.version}`),null==t&&(t={}),t&&"object"==typeof t||o(`Failed to register mod ${i}: Expected options to be undefined or object, got ${typeof t}`);const a=!0===t.allowReplace,d=p.get(e.name);d&&(d.allowReplace&&a||o(`Refusing to load mod ${i}: it is already loaded and doesn't allow being replaced.\nWas the mod loaded multiple times?`),u(d));const s=e=>{"string"==typeof e&&e||o(`Mod ${i} failed to patch a function: Expected function name string, got ${typeof e}`);let t=g.patching.get(e);return t||(t={hooks:[],patches:new Map},g.patching.set(e,t)),t},f={unload:()=>u(g),hookFunction:(e,t,n)=>{g.loaded||o(`Mod ${i} attempted to call SDK function after being unloaded`);const r=s(e);"number"!=typeof t&&o(`Mod ${i} failed to hook function '${e}': Expected priority number, got ${typeof t}`),"function"!=typeof n&&o(`Mod ${i} failed to hook function '${e}': Expected hook function, got ${typeof n}`);const a={mod:g.name,priority:t,hook:n};return r.hooks.push(a),l(),()=>{const e=r.hooks.indexOf(a);e>=0&&(r.hooks.splice(e,1),l())}},patchFunction:(e,t)=>{g.loaded||o(`Mod ${i} attempted to call SDK function after being unloaded`);const r=s(e);n(t)||o(`Mod ${i} failed to patch function '${e}': Expected patches object, got ${typeof t}`);for(const[n,a]of Object.entries(t))"string"==typeof a?r.patches.set(n,a):null===a?r.patches.delete(n):o(`Mod ${i} failed to patch function '${e}': Invalid format of patch '${n}'`);l()},removePatches:e=>{g.loaded||o(`Mod ${i} attempted to call SDK function after being unloaded`);s(e).patches.clear(),l()},callOriginal:(e,t,n)=>(g.loaded||o(`Mod ${i} attempted to call SDK function after being unloaded`),"string"==typeof e&&e||o(`Mod ${i} failed to call a function: Expected function name string, got ${typeof e}`),Array.isArray(t)||o(`Mod ${i} failed to call a function: Expected args array, got ${typeof t}`),function(e,o,t=window){return c(e).original.apply(t,o)}(e,t,n)),getOriginalHash:e=>("string"==typeof e&&e||o(`Mod ${i} failed to get hash: Expected function name string, got ${typeof e}`),c(e).originalHash)},g={name:e.name,fullName:e.fullName,version:e.version,repository:e.repository,allowReplace:a,api:f,loaded:!0,patching:new Map};return p.set(e.name,g),Object.freeze(f)}function h(){const e=[];for(const o of p.values())e.push({name:o.name,fullName:o.fullName,version:o.version,repository:o.repository});return e}let m;const y=function(){if(void 0===window.bcModSdk)return window.bcModSdk=function(){const o={version:e,apiVersion:1,registerMod:g,getModsInfo:h,getPatchingInfo:f,errorReporterHooks:Object.seal({hookEnter:null,hookChainExit:null})};return m=o,Object.freeze(o)}();if(n(window.bcModSdk)||o("Failed to init Mod SDK: Name already in use"),1!==window.bcModSdk.apiVersion&&o(`Failed to init Mod SDK: Different version already loaded ('1.1.0' vs '${window.bcModSdk.version}')`),window.bcModSdk.version!==e&&(alert(`Mod SDK warning: Loading different but compatible versions ('1.1.0' vs '${window.bcModSdk.version}')\nOne of mods you are using is using an old version of SDK. It will work for now but please inform author to update`),window.bcModSdk.version.startsWith("1.0.")&&void 0===window.bcModSdk._shim10register)){const e=window.bcModSdk,o=Object.freeze(Object.assign(Object.assign({},e),{registerMod:(o,t,n)=>o&&"object"==typeof o&&"string"==typeof o.name&&"string"==typeof o.version?e.registerMod(o.name,o.version,"object"==typeof t&&!!t&&!0===t.allowReplace):e.registerMod(o,t,n),_shim10register:!0}));window.bcModSdk=o}return window.bcModSdk}();return"undefined"!=typeof exports&&(Object.defineProperty(exports,"__esModule",{value:!0}),exports.default=y),y}();
 
 // SDK stuff
@@ -1033,7 +1034,7 @@ const TriggerAdditions = [
         // Many items don't tether/chain/etc but ought to prevent flying
         const otherPreventingItemNames = ["CeilingShackles", "FloorShackles", "SuspensionCuffs", "CeilingRope", "CeilingChain", "BallChain"];
         const preventingItem = Player.Appearance.find(i => (
-            ["Tethered", "Chained", "Mounted", "Enclose", "IsLeashed", "IsChained"].some(e => InventoryItemHasEffect(i, e))
+            /** @type {EffectName[]} */(["Tethered", "Chained", "Mounted", "Enclose", "IsLeashed", "IsChained"]).some(e => InventoryItemHasEffect(i, e))
             || otherPreventingItemNames.includes(i.Asset.Name)
         ));
         if (preventingItem) {
@@ -1101,18 +1102,19 @@ const TriggerAdditions = [
 
     const restraints = ["CollarChainLong", "CollarRopeLong", "CollarChainMedium", "CollarRopeMedium", "CollarChainShort", "CollarRopeShort", "Post", "PetPost"]
     window.ChatRoomRegisterMessageHandler({ Priority: -200, Description: "BCAR+ Ground flying players with chains", Callback: (data, sender, msg, metadata) => {
-        if ("ActionUse" != msg) return // this is not our message
+        if ("ActionUse" != msg) return false; // this is not our message
         let asset_name, dest
         for (let item of data.Dictionary) {
             if ('NextAsset' === item.Tag) asset_name = item.AssetName
             if ('DestinationCharacter' === item.Tag) dest = item.MemberNumber
         }
-        if (!restraints.includes(asset_name)) return // this is not our asset
-        if (dest !== Player.MemberNumber) return // we are not the receiver
-        if (!InventoryGet(Player, 'Emoticon')?.Property?.OverrideHeight) return // we are not flying
+        if (!restraints.includes(asset_name)) return false; // this is not our asset
+        if (dest !== Player.MemberNumber) return false; // we are not the receiver
+        if (!InventoryGet(Player, 'Emoticon')?.Property?.OverrideHeight) return false; // we are not flying
         delete InventoryGet(Player, 'Emoticon')?.Property?.OverrideHeight
         ChatRoomCharacterUpdate(Player)
         ServerSend("ChatRoomChat", { Content: "Beep", Type: "Action", Dictionary: [{Tag: "Beep", Text: `${CharacterNickname(Player)} was dragged to the ground by a ${Asset.find(a => a.Name === asset_name).Description}.` }]})
+        return false;
     }})
 
 
@@ -1213,6 +1215,7 @@ const TriggerAdditions = [
           WingsHide();
         }
       }
+      return false;
 }});
 
     window.ChatRoomRegisterMessageHandler({ Priority: 600, Description: "BCAR+ Activites", Callback: (data, sender, msg, metadata) => {
@@ -1222,12 +1225,13 @@ const TriggerAdditions = [
             case "OrgasmFailSurrender": StopLeaving("ruined orgasm"); break;
             default: // nothing to do here, but linters often insist every switch() has a default case
         }
+        return false;
     }});
 
 window.ChatRoomRegisterMessageHandler({ Priority: 600, Description: "BCAR+ Auto Reactions", Callback: (data, sender, msg, metadata) => {
-  if (data.Type !== 'Activity') return // isn't an Activity message
+  if (data.Type !== 'Activity') return false; // isn't an Activity message
   //console.log(data);
-  if (!Player?.MemberNumber) return // we need Player.MemberNumber
+  if (!Player?.MemberNumber) return false; // we need Player.MemberNumber
   let target_number = data.Dictionary.find(obj => obj.TargetCharacter)?.TargetCharacter;
       target_number ||= data.Dictionary.find(obj => obj.Tag === "TargetCharacter")?.MemberNumber;
   //if (Player.MemberNumber !== data.Dictionary.find(obj => obj.Tag === "TargetCharacter")?.MemberNumber) return // we aren't the target
@@ -1296,6 +1300,7 @@ window.ChatRoomRegisterMessageHandler({ Priority: 600, Description: "BCAR+ Auto 
             ArousalCaressButt();
             break;
     }
+    return false;
 }});
 
     function bcarSettingsSave() {
@@ -1349,6 +1354,7 @@ async function bcarSettingsRemove() {
 
     async function bcarSettingsLoad() {
 		await waitFor(() => !!Player?.AccountName);
+        /** @type {BCARSettings} */
         const BCAR_DEFAULT_SETTINGS = {
             animal : "human",
             animationButtonsEnable : false,
@@ -1533,7 +1539,7 @@ async function bcarSettingsRemove() {
 
 
         // if there are no settings on the server initialize with an empty object
-        Player.BCAR = Player.OnlineSettings.BCAR || {bcarSettings: {}}
+        Player.BCAR = /** @type {BCAR} */(Player.OnlineSettings.BCAR || {bcarSettings: {}});
         //if online settings are not an older version then local ones, use them instead
 
         const settings = migrateSettings() || Player.OnlineSettings.BCAR?.bcarSettings || {}
@@ -1558,6 +1564,7 @@ async function bcarSettingsRemove() {
         Player.BCAR.bcarSettings = settings;
 
         migrate_gender();
+        // @ts-expect-error deprecated
         delete Player.BCAR.bcarSettings.asleep
         bcarSettingsSave();
     }
@@ -2367,6 +2374,7 @@ function CommandConfirmAbort(arglist)
                 break;
             case 'yes' :
                 if (confirmationState.ears) {
+                    // @ts-expect-error
                     s.earsDefault = {};
                     s.earsDefault.earsDescription1 = "None";
                     s.earsDefault.earsDescription2 = "None";
@@ -2382,6 +2390,7 @@ function CommandConfirmAbort(arglist)
                     InventoryRemove(Player, "HairAccessory2")
                 }
                 if (confirmationState.tails) {
+                    // @ts-expect-error
                     s.tailsDefault = {};
                     s.tailsDefault.tailsDescription1 = "None";
                     s.tailsDefault.tailsDescription2 = "None";
@@ -2397,6 +2406,7 @@ function CommandConfirmAbort(arglist)
                     InventoryRemove(Player, "TailStraps")
                 }
                 if (confirmationState.wings) {
+                    // @ts-expect-error
                     s.wingsDefault = {};
                     s.wingsDefault.wingsDescription1 = "None";
                     s.wingsDefault.wingsDescription2 = "None";
@@ -4614,6 +4624,7 @@ CommandCombine([
         if (MouseIn(500 + 250, getYPos(3) - 32, 200, 64)) {
             const s = Player?.BCAR?.bcarSettings;
             if (confirmationState.ears) {
+                // @ts-expect-error
                 s.earsDefault = {};
                 s.earsDefault.earsDescription1 = "None";
                 s.earsDefault.earsDescription2 = "None";
@@ -4625,6 +4636,7 @@ CommandCombine([
                 PreferenceMessage = "Ears has been removed";
             }
             if (confirmationState.tails) {
+                // @ts-expect-error
                 s.tailsDefault = {};
                 s.tailsDefault.tailsDescription1 = "None";
                 s.tailsDefault.tailsDescription2 = "None";
@@ -4636,6 +4648,7 @@ CommandCombine([
                 PreferenceMessage = "Tails has been removed";
             }
             if (confirmationState.wings) {
+                // @ts-expect-error
                 s.wingsDefault = {};
                 s.wingsDefault.wingsDescription1 = "None";
                 s.wingsDefault.wingsDescription2 = "None";
@@ -4739,8 +4752,8 @@ CommandCombine([
     }
           /// CUSTOM ACTIVITIES
 
-    CustomPrerequisiteFuncs = new Map();
-    CustomImages = new Map();
+    const CustomPrerequisiteFuncs = new Map();
+    const CustomImages = new Map();
 
     const AnimationsMap = { // this one is new
       BCAR_TailWag: TailWag,

--- a/script/bcarBeta.js
+++ b/script/bcarBeta.js
@@ -1144,53 +1144,53 @@ const TriggerAdditions = [
           let patterns = [/wags.*tail/mi, /tail.*wagging/mi, /wagging.*tail/mi] ; // matches {<any> wags <any> tail <any>}
           let result = patterns.find(pattern => pattern.test(wagMessage));
           if(result){
-              if (Player.BCT?.bctSettings?.tailWaggingEnable && Player.BCAR.bcarSettings.tailEmoteEnable){
-          ChatRoomSendLocal(
-                    `<p style='background-color:#630A0A;color:#EEEEEE;'><b>Bondage Club Auto React +</b>
-                    <br>Please disable tail wagging in either BCT or BCAR.
-                    <br>Having them both can cause undesireable and wonky results.
-                    </p>`.replaceAll('\n', ''), wt.info
+            if (Player.BCT?.bctSettings?.tailWaggingEnable && Player.BCAR.bcarSettings.tailEmoteEnable){
+              ChatRoomSendLocal(
+                `<p style='background-color:#630A0A;color:#EEEEEE;'><b>Bondage Club Auto React +</b>
+                <br>Please disable tail wagging in either BCT or BCAR.
+                <br>Having them both can cause undesireable and wonky results.
+                </p>`.replaceAll('\n', ''), wt.info
                 )
-      }
+              }
               TailWag();
-          }
+            }
       }
-
-        if(data.Type === "Emote" && data.Sender === Player.MemberNumber && Player.BCAR.bcarSettings.earEmoteEnable){
-          var wiggleMessage = data.Content;
-          let patterns = [/wiggles.*ears/mi, /ears.*wiggling/mi, /wiggling.*ears/mi] ; // matches {<any> wags <any> tail <any>}
-          let result = patterns.find(pattern => pattern.test(wiggleMessage));
-          if(result){
-              EarWiggle();
-          }
+      
+      if(data.Type === "Emote" && data.Sender === Player.MemberNumber && Player.BCAR.bcarSettings.earEmoteEnable){
+        var wiggleMessage = data.Content;
+        let patterns = [/wiggles.*ears/mi, /ears.*wiggling/mi, /wiggling.*ears/mi] ; // matches {<any> wags <any> tail <any>}
+        let result = patterns.find(pattern => pattern.test(wiggleMessage));
+        if(result){
+          EarWiggle();
+        }
       }
-
-    if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
-          var wingsSpreadMessage = data.Content;
-          let patterns = [/shows.*wings/mi, /spreads.*wings/mi] ; // matches {<any> spreads <any> wings <any>}
-          let result = patterns.find(pattern => pattern.test(wingsSpreadMessage));
-          if(result){
-              WingsSpread();
-          }
+      
+      if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
+        var wingsSpreadMessage = data.Content;
+        let patterns = [/shows.*wings/mi, /spreads.*wings/mi] ; // matches {<any> spreads <any> wings <any>}
+        let result = patterns.find(pattern => pattern.test(wingsSpreadMessage));
+        if(result){
+          WingsSpread();
+        }
       }
-
-    if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
-          var flapMessage = data.Content;
-          let patterns = [/(flaps|flutters).*wings/mi, /wings.*(flapping|fluttering)/mi, /(flapping|fluttering).*wings/mi, /wings.*(flap|flutter)/mi] ; // matches {<any> flaps/flutter <any> wings <any>}
-          let result = patterns.find(pattern => pattern.test(flapMessage));
-          if(result){
-              WingFlap();
-          }
+      
+      if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
+        var flapMessage = data.Content;
+        let patterns = [/(flaps|flutters).*wings/mi, /wings.*(flapping|fluttering)/mi, /(flapping|fluttering).*wings/mi, /wings.*(flap|flutter)/mi] ; // matches {<any> flaps/flutter <any> wings <any>}
+        let result = patterns.find(pattern => pattern.test(flapMessage));
+        if(result){
+          WingFlap();
+        }
       }
-
-    if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
-          var flyMessage = data.Content;
-          let patterns = [/begins.*fly/mi, /starts.*flying/mi] ; // matches {<any> begins <any> fly <any>}
-          let result = patterns.find(pattern => pattern.test(flyMessage));
-
-          if(result){
-              TryFly();
-          }
+      
+      if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
+        var flyMessage = data.Content;
+        let patterns = [/begins.*fly/mi, /starts.*flying/mi] ; // matches {<any> begins <any> fly <any>}
+        let result = patterns.find(pattern => pattern.test(flyMessage));
+        
+        if(result){
+          TryFly();
+        }
       }
 
 
@@ -1203,15 +1203,15 @@ const TriggerAdditions = [
               Landing();
           }
       }
-
-    if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
-          var wingsHideMessage = data.Content;
-          let patterns = [/hides.*wings/mi, /folds.*wings/mi, /retracts.*wings/mi] ; // matches {<any> flaps <any> wings <any>}
-          let result = patterns.find(pattern => pattern.test(wingsHideMessage));
-          if(result){
-              Landing();
-              WingsHide();
-          }
+      
+      if(data.Type === "Emote" && data.Sender === Player.MemberNumber){
+        var wingsHideMessage = data.Content;
+        let patterns = [/hides.*wings/mi, /folds.*wings/mi, /retracts.*wings/mi] ; // matches {<any> flaps <any> wings <any>}
+        let result = patterns.find(pattern => pattern.test(wingsHideMessage));
+        if(result){
+          Landing();
+          WingsHide();
+        }
       }
 }});
 

--- a/script/bce.d.ts
+++ b/script/bce.d.ts
@@ -1,0 +1,308 @@
+export {};
+
+declare global {
+  // Dexie
+  // var Dexie: import("dexie").DexieConstructor;
+
+  // FBC
+  var FBC_VERSION: string;
+  var fbcSendAction: (text: string) => void;
+  var fbcPushEvent: (evt: ExpressionEvent) => void;
+  var fbcChatNotify: (node: HTMLElement | HTMLElement[] | string) => void;
+  var fbcDebug: (copy?: boolean) => Promise<string>;
+  var fbcSettingValue: (key: string) => boolean | number | string;
+  var bceAnimationEngineEnabled: () => boolean;
+  var bce_initializeDefaultExpression: () => void;
+  var bceUpdatePasswordForReconnect: () => void;
+  var bceMessageReplacements: (msg: string) => string;
+  var bce_EventExpressions: { [key: string]: Expression };
+  var bceClearPassword: (name: string) => void;
+  var bceClearCaches: () => Promise<void>;
+  var fbcDisplayText: (
+    original: string,
+    replacements?: Record<string, string>
+  ) => string;
+  var bceStripBeepMetadata: (text: string) => string;
+  var bce_ArousalExpressionStages: ArousalExpressionStages;
+  var bce_ActivityTriggers: ActivityTrigger[];
+  var PreferenceSubscreenBCESettingsLoad: () => void;
+  var PreferenceSubscreenBCESettingsExit: () => void;
+  var PreferenceSubscreenBCESettingsRun: () => void;
+  var PreferenceSubscreenBCESettingsClick: () => void;
+  var bceGotoRoom: (room: string) => void;
+  var bceStartClubSlave: () => Promise<void>;
+  var bceSendToClubSlavery: () => void;
+  var bceCanSendToClubSlavery: () => boolean;
+  // used by the game's dialog functions
+  var ChatRoombceSendToClubSlavery: () => void;
+  var ChatRoombceCanSendToClubSlavery: () => boolean;
+
+  // Mod SDK - can technically be undefined, but the script checks on startup and bails, if not present
+  var bcModSdk: import("bondage-club-mod-sdk").ModSDKGlobalAPI;
+
+  // FUSAM - can technically be undefined, but the script checks on startup and bails, if not present
+  var FUSAM: FUSAMPublicAPI;
+
+  // // BCX
+  // var bcx:
+  //   | import("./types/bcxExternalInterface").BCX_ConsoleInterface
+  //   | undefined;
+
+  // var BCX_Loaded: boolean;
+  // var BCX_SOURCE: string;
+
+  // Misc addon globals
+  var StartBcUtil: () => void;
+}
+declare global {
+  var GM_info: unknown;
+  interface Window {
+    InputChat?: HTMLTextAreaElement;
+    MainCanvas: HTMLCanvasElement;
+  }
+  type Passwords = Record<string, string>;
+  type SettingsCategory =
+    | "performance"
+    | "chat"
+    | "activities"
+    | "immersion"
+    | "appearance"
+    | "misc"
+    | "cheats"
+    | "buttplug"
+    | "hidden";
+  type DefaultSettingBase = {
+    label: string;
+    type?: "boolean" | "string";
+    sideEffects: (newValue: boolean | string) => void;
+    category: SettingsCategory;
+    description: string;
+  };
+
+  type DefaultSettingBoolean = DefaultSettingBase & {
+    value: boolean;
+  };
+
+  type DefaultSettingString = DefaultSettingBase & {
+    value: string;
+  };
+
+  type DefaultSetting = DefaultSettingBoolean | DefaultSettingString;
+
+  type FBCNote = {
+    note: string;
+    updatedAt?: number;
+  };
+  type FBCDuration = {
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+  };
+  type Craft = {
+    Color: string;
+    Description: string;
+    Item: string;
+    Lock: string;
+    Name: string;
+    Property: string;
+  };
+  type AccountUpdater = {
+    QueueData: (data: Partial<Character>, force?: boolean) => void;
+  };
+  type LZStringType = {
+    compressToBase64: (data: string) => string;
+    compressToUTF16: (data: string) => string;
+    decompressFromBase64: (data: string) => string;
+    decompressFromUTF16: (data: string) => string;
+  };
+  type ServerBeep = {
+    Timer: number;
+    MemberNumber?: number;
+    Message: string;
+    ChatRoomName?: string;
+    IsMail?: boolean;
+    ClickAction?: "FriendList";
+  };
+  type ItemProperty = {
+    RemoveTimer?: number;
+    ShowTimer?: boolean;
+    Intensity?: number;
+    Expression?: string;
+    OverridePriority?: number | Record<string, number>;
+    LockMemberNumber?: number;
+    LockedBy?: string;
+    Effect?: string[];
+    BlinkState?: unknown;
+  };
+  type ItemLayer = Item & { Name: string | null; Priority?: number };
+  type ArousalExpressionStage = {
+    Expression: ExpressionName | null;
+    Limit: number;
+  };
+  type ArousalExpressionStages = Record<string, ArousalExpressionStage[]>;
+  type ClubPose = {
+    Name: string;
+    Category?: string;
+    AllowMenu?: boolean;
+  };
+  type ExpressionStage = {
+    Id?: number;
+    Expression?: ExpressionName;
+    ExpressionModifier?: number;
+    Duration: number;
+    Priority?: number;
+    Skip?: boolean;
+    Color?: string | string[];
+    Applied?: boolean;
+  };
+  type ExpressionStages = Record<string, ExpressionStage[]>;
+  type FBCPose = {
+    Id?: number;
+    Pose: AssetPoseName[];
+    Duration: number;
+    Priority?: number;
+  };
+  type Expression = {
+    Type: string;
+    Duration: number;
+    Priority?: number;
+    Expression?: ExpressionStages;
+    Poses?: FBCPose[];
+  };
+  type EventParams = {
+    At?: number;
+    Until?: number;
+    Id?: number;
+  };
+  type ExpressionEvent = Expression & EventParams;
+  type ActivityTriggerMatcher = {
+    Tester: RegExp;
+    Criteria?: {
+      TargetIsPlayer?: boolean;
+      SenderIsPlayer?: boolean;
+      DictionaryMatchers?: Record<string, string>[];
+    };
+  };
+  type ActivityTrigger = {
+    Event: string;
+    Type: string;
+    Matchers: ActivityTriggerMatcher[];
+  };
+  // type ServerSocketEvent =
+  //   import("./node_modules/@socket.io/component-emitter/index").ReservedOrUserEventNames<
+  //     import("./node_modules/@socket.io/component-emitter/index").DefaultEventsMap,
+  //     ServerToClientEvents
+  //   >;
+
+  type Command = {
+    Tag: string;
+    Description?: string;
+    Reference?: string;
+    Action?: (args: string, msg: string, parsed: string[]) => unknown;
+    Prerequisite?: () => boolean;
+    AutoComplete?: (parsed: string[], low: string, msg: string) => void;
+    Clear?: false;
+  };
+  type Position = {
+    X: number;
+    Y: number;
+    Width: number;
+    Height: number;
+  };
+  type Friend = {
+    MemberName: string;
+    MemberNumber: number;
+  };
+  type BCEActivity = "ClubSlavery";
+  type BCEMessage = {
+    type: string;
+    version: string;
+    capabilities?: readonly string[];
+    blockAntiGarble?: boolean;
+    alternateArousal?: boolean;
+    replyRequested?: boolean;
+    progress?: number;
+    enjoyment?: number;
+    activity?: BCEActivity;
+    otherAddons?: readonly import("bondage-club-mod-sdk").ModSDKModInfo[];
+  };
+
+  type FBCDictionaryEntry = {
+    message: BCEMessage;
+  };
+
+  type FBCToySetting = {
+    Name: string;
+    SlotName: string;
+    LastIntensity?: number;
+  };
+  type FBCToySyncState = {
+    client?: any; /* import("./types/buttplug.io.1.0.17").ButtplugClient */
+    deviceSettings: Map<string, FBCToySetting>;
+  };
+
+  type FBCSavedProfile = {
+    memberNumber: number;
+    name: string;
+    lastNick?: string;
+    seen: number;
+    characterBundle: string;
+  };
+
+  type FUSAMPublicAPI = {
+    present: true;
+    addons: Record<string, FUSAMAddonState>;
+    registerDebugMethod: (
+      name: string,
+      method: () => string | Promise<string>
+    ) => void;
+    modals: {
+      open: (options: ModalOptions) => void;
+      openAsync: (
+        options: Omit<ModalOptions, "callback">
+      ) => Promise<[string, string | null]>;
+    };
+  };
+
+  type FUSAMAddonState = {
+    distribution: string;
+    status: "loading" | "loaded" | "error";
+  };
+
+  type ModalOptions = {
+    prompt: string | Node;
+    input?: { initial: string; readonly: boolean; type: "input" | "textarea" };
+    callback: (action: string, inputValue?: string) => void;
+    buttons?: { submit: string } & Record<string, string>;
+  };
+
+  // type SocketEventListenerRegister = [ServerSocketEvent, SocketEventListener][];
+
+  type SocketEventListener = () => Promise<void> | void;
+
+  // Interface extensions
+  interface Character {
+    FBC: string;
+    FBCOtherAddons?: readonly import("bondage-club-mod-sdk").ModSDKModInfo[];
+    BCEArousal: boolean;
+    BCECapabilities: readonly string[];
+    BCEBlockAntiGarble?: boolean;
+    BCEArousalProgress: number;
+    BCEEnjoyment: number;
+    BCESeen: number;
+  }
+  interface PlayerOnlineSettings {
+    /** @deprecated */
+    BCE?: string;
+    /** @deprecated */
+    BCEWardrobe?: string;
+  }
+  interface CharacterOnlineSharedSettings {
+    Uwall?: boolean;
+  }
+  interface ExtensionSettings {
+    FBC: string;
+    FBCWardrobe: string;
+  }
+}

--- a/script/global.d.ts
+++ b/script/global.d.ts
@@ -1,0 +1,151 @@
+
+declare var BCAR_VERSION: string;
+declare var LoadedError: typeof Error | ErrorConstructor;
+declare var bcModSdk: import("bondage-club-mod-sdk").ModSDKGlobalAPI;
+
+declare function prefix(words: string[]): string;
+
+declare var BCT_API: any;
+
+interface PlayerCharacter {
+  BCAR: BCAR;
+  BCT: any;
+}
+
+interface PlayerOnlineSettings {
+  BCAR: BCAR;
+}
+
+interface BCAR {
+  bcarSettings: BCARSettings;
+}
+
+interface BCARSettings {
+  animationButtonsEnable: boolean;
+  animationButtonsPosition: "upperleft" | "lowerleft" | "lowerright";
+  arousalEnable: boolean;
+  arousalStatus: "Enabled" | "Disabled";
+  expressionsEnable: boolean;
+  expressionsStatus: "Enabled" | "Disabled";
+  earWigglingEnable: boolean;
+  earWigglingStatus: "Enabled" | "Disabled";
+  tailWaggingEnable: boolean;
+  tailWaggingStatus: "Enabled" | "Disabled";
+  wingFlappingEnable: boolean;
+  wingFlappingStatus: "Enabled" | "Disabled";
+  tailEmoteEnable: boolean;
+  tailEmoteStatus: "Enabled" | "Disabled";
+  earEmoteEnable: boolean;
+  earEmoteStatus: "Enabled" | "Disabled";
+  animal: string;
+  genderDefault: {
+    gender: "Male" | "Female" | "Non-Binary";
+    pronoun: "";
+    capPronoun: "He" | "She" | "They";
+    intensive: "";
+    capIntensive: "Him" | "Her" | "Them";
+    possessive: "";
+    capPossessive: "His" | "Her" | "Their";
+  };
+  earsDefault: {
+    ears1: string;
+    ears2: string;
+    earsColor1: HexColor | HexColor[];
+    earsDescription1: string;
+    earsColor2: HexColor | HexColor[];
+    earsDescription2: string;
+    earsCount: number;
+    earsDelay: number;
+  }
+  tailsDefault: {
+    tails1: string;
+    tails2: string;
+    tailsColor1: HexColor | HexColor[];
+    tailsDescription1: string;
+    tailsColor2: HexColor | HexColor[];
+    tailsDescription2: string;
+    tailsCount: number;
+    tailsDelay: number;
+  }
+  wingsDefault: {
+    wings1: string;
+    wings2: string;
+    wingsColor1: HexColor | HexColor[];
+    wingsDescription1: string;
+    wingsColor2: HexColor | HexColor[];
+    wingsDescription2: string;
+    wingsCount: number;
+    wingsDelay: number;
+  };
+  profile1: BCARProfile;
+  profile1Saved: boolean;
+  profile2: BCARProfile;
+  profile2Saved: boolean;
+  profile3: BCARProfile;
+  profile3Saved: boolean;
+  windowTimer: {
+    changelog: number;
+    commands: number;
+    ghelp: number;
+    help: number;
+    info: number;
+    timerEnable: boolean;
+  };
+}
+
+interface BCARProfile {
+  earWigglingEnable: boolean;
+  earWigglingStatus: "Enabled" | "Disabled";
+  earsDefault: BCARSettings["earsDefault"];
+  tailWaggingEnable: boolean;
+  tailWaggingStatus: "Enabled" | "Disabled";
+  tailsDefault: BCARSettings["tailsDefault"];
+  wingFlappingEnable: boolean;
+  wingFlappingStatus: "Enabled" | "Disabled";
+  wingsDefault: BCARSettings["wingsDefault"];
+}
+
+declare function PreferenceSubscreenBCARSettingsLoad();
+declare function PreferenceSubscreenBCARSettingsRun();
+declare function PreferenceSubscreenBCARSettingsClick();
+declare function PreferenceSubscreenBCARSettingsExit();
+
+declare function PreferenceSubscreenBCARCommandsLoad();
+declare function PreferenceSubscreenBCARCommandsRun();
+declare function PreferenceSubscreenBCARCommandsClick();
+declare function PreferenceSubscreenBCARCommandsExit();
+
+declare function PreferenceSubscreenBCAREarsLoad();
+declare function PreferenceSubscreenBCAREarsRun();
+declare function PreferenceSubscreenBCAREarsClick();
+declare function PreferenceSubscreenBCAREarsExit();
+
+declare function PreferenceSubscreenBCARTailLoad();
+declare function PreferenceSubscreenBCARTailRun();
+declare function PreferenceSubscreenBCARTailClick();
+declare function PreferenceSubscreenBCARTailExit();
+
+declare function PreferenceSubscreenBCARWingsLoad();
+declare function PreferenceSubscreenBCARWingsRun();
+declare function PreferenceSubscreenBCARWingsClick();
+declare function PreferenceSubscreenBCARWingsExit();
+
+declare function PreferenceSubscreenBCARMiscLoad();
+declare function PreferenceSubscreenBCARMiscRun();
+declare function PreferenceSubscreenBCARMiscClick();
+declare function PreferenceSubscreenBCARMiscExit();
+
+declare function PreferenceSubscreenBCARProfilesLoad();
+declare function PreferenceSubscreenBCARProfilesRun();
+declare function PreferenceSubscreenBCARProfilesClick();
+declare function PreferenceSubscreenBCARProfilesExit();
+
+declare function PreferenceSubscreenBCARConfirmAbortLoad();
+declare function PreferenceSubscreenBCARConfirmAbortRun();
+declare function PreferenceSubscreenBCARConfirmAbortClick();
+declare function PreferenceSubscreenBCARConfirmAbortExit();
+
+declare function PreferenceSubscreenBCARReactionsLoad();
+declare function PreferenceSubscreenBCARReactionsRun();
+declare function PreferenceSubscreenBCARReactionsClick();
+declare function PreferenceSubscreenBCARReactionsExit();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "lib": ["ESNext", "dom"],
+        "types": [],
+        "module": "ESNext",
+        "moduleResolution": "Node",
+        "sourceMap": true,
+        "removeComments": false,
+        "outDir": "./dist",
+        // "strict": true,
+        "noEmit": true,
+        "experimentalDecorators": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "checkJs": true,
+    },
+    "include": [
+        "node_modules/bc-stubs/bc/**/*.d.ts",
+        "./script/**/*",
+        "loader.user.js",
+    ]
+}


### PR DESCRIPTION
This sets up the bare minimum needed to get VSCode to be type-aware around here. I tried to fix as much of the errors through typing I could, but there's a few things I left because they're either wrong, I couldn't understand the reason, or was just lazy.

This loads Rama's bc-stubs & ModSDK, which you'll need to keep updated through npm, and FBC's API defs which are copied from its repo, and types out most of BCAR's internal API, giving visibility into deprecations, errors and all that jazz.