### PR TITLE
Fix a crash because of a renamed function

### DIFF
--- a/script/bcarBeta.js
+++ b/script/bcarBeta.js
@@ -3024,8 +3024,7 @@ CommandCombine([
         Description:": opens your wardrobe.",
 
         Action: args => {
-            ChatRoomClickCharacter(Player);
-            DialogChangeClothes();
+            ChatRoomAppearanceLoadCharacter(Player);
         }
     }])
 


### PR DESCRIPTION
I'm not sure what were the expected side-effects from calling the click handler directly (there's a lot, and the mouse position would be mostly random at that point). So instead, just use the "open wardrobe screen" function directly.

I didn't test this at all, just was bored and someone discovered the crash.