### PR TITLE
Ensure that the `/leave` command respects the players `PreserveChat` settings

### DIFF
--- a/script/bcar.js
+++ b/script/bcar.js
@@ -2977,8 +2977,13 @@ CommandCombine([
         Action: args => {
             if (CurrentScreen == "ChatRoom") {
                 ElementRemove("FriendList");
-                ElementRemove("InputChat");
-                ElementRemove("TextAreaChatLog");
+                if (Player.ChatSettings?.PreserveChat ?? true) {
+                    ChatRoomHideElements();
+                } else {
+                    ElementRemove("InputChat");
+                    ElementRemove("TextAreaChatLog");
+                }
+
                 ChatRoomSetLastChatRoom("");
                 ServerSend("ChatRoomLeave", "");
                 CommonSetScreen("Online", "ChatSearch");

--- a/script/bcarBeta.js
+++ b/script/bcarBeta.js
@@ -2977,8 +2977,13 @@ CommandCombine([
         Action: args => {
             if (CurrentScreen == "ChatRoom") {
                 ElementRemove("FriendList");
-                ElementRemove("InputChat");
-                ElementRemove("TextAreaChatLog");
+                if (Player.ChatSettings?.PreserveChat ?? true) {
+                    ChatRoomHideElements();
+                } else {
+                    ElementRemove("InputChat");
+                    ElementRemove("TextAreaChatLog");
+                }
+
                 ChatRoomSetLastChatRoom("");
                 ServerSend("ChatRoomLeave", "");
                 CommonSetScreen("Online", "ChatSearch");


### PR DESCRIPTION
Do not unconditionally delete the `InputChat` and `TextAreaChatLog` elements whenever running the `/leave`, instead respecting the players `PreserveChat` settings which govern whether or not the chat log is preserved when changing rooms.