### PR TITLE
fixed ear wiggle misgendering you

### DIFF
--- a/script/bcar.js
+++ b/script/bcar.js
@@ -71,19 +71,7 @@ var bcModSDK=function(){"use strict";const o="1.2.0";function e(o){alert("Mod ER
     BCARChatRoomMenuDraw();
     BCARChatRoomClick();
 
-    function BCARTriggerEarWiggleAction() {
-        let focusGroup = Player.FocusGroup;
-        Player.FocusGroup = {Name:"ItemEars"};
-        ActivityRun(
-            Player,
-            Player,
-            ActivityGetGroupOrMirror(Player.AssetFamily, "ItemEars"),
-            ActivityAllowedForGroup(Player, "ItemEars").find(function(obj){
-                return obj.Activity.Name == "Wiggle";
-            })
-        );
-        Player.FocusGroup = focusGroup;
-    }
+
 
     const getWingVerb = () => ["FairyWings", "BeeWings", "PixieWings"].includes(InventoryGet(Player,"Wings")?.Asset?.Name) ? "flutters" : "flaps";
 
@@ -98,7 +86,17 @@ var bcModSDK=function(){"use strict";const o="1.2.0";function e(o){alert("Mod ER
                         || ((Player.BCAR.bcarSettings.animationButtonsPosition === "lowerright")
                             && ((MouseX >= 955) && (MouseX < 1005) && (MouseY >= 860) && (MouseY < 905))))
                     {
-                        BCARTriggerEarWiggleAction()
+                        ServerSend("ChatRoomChat", {
+                            Content: "Beep",
+                            Type: "Action",
+                            Target: null,
+                            Dictionary: [
+                                { Tag: "Beep", Text: "msg" },
+                                { Tag: "Biep", Text: "msg" },
+                                { Tag: "Sonner", Text: "msg" },
+                                { Tag: "msg", Text: CharacterNickname(Player) + " wiggles " + Player.BCAR.bcarSettings.genderDefault.capPossessive.toLocaleLowerCase() + " ears." }
+                            ]
+                        });
                         EarWiggle();
                         return;
                     }


### PR DESCRIPTION
fixed a bug causing ear wiggles to not respect bcar pronoun settings because instead of writing text it instead called the BC built in ear wiggle function, which uses a different pronoun setting