### PR TITLE
Adapt to the R111 dialog `activities` mode rework

### DIFF
--- a/script/bcar.js
+++ b/script/bcar.js
@@ -4844,16 +4844,28 @@ CommandCombine([
     });
 
     // -- Support for repointing or adding custom image thumbnails to activities
-    modApi.hookFunction("DrawImageResize", 1, (args, next) => {
-        var path = args[0];
-        if (!!path && (typeof path === 'string') && path.indexOf("BCAR_") > -1) {
-            var activityName = path.substring(path.indexOf("BCAR_"));
-            activityName = activityName.substring(0, activityName.indexOf(".png"))
-            if (CustomImages.has(activityName))
-                args[0] = CustomImages.get(activityName);
-        }
-        return next(args);
-    });
+    if (GameVersion === "R110") {
+        modApi.hookFunction("DrawImageResize", 1, (args, next) => {
+            var path = args[0];
+            if (!!path && (typeof path === 'string') && path.indexOf("BCAR_") > -1) {
+                var activityName = path.substring(path.indexOf("BCAR_"));
+                activityName = activityName.substring(0, activityName.indexOf(".png"))
+                if (CustomImages.has(activityName))
+                    args[0] = CustomImages.get(activityName);
+            }
+            return next(args);
+        });
+    } else { // R111
+        modApi.hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
+            /** @type {ItemActivity} */
+            const activity = args[1];
+            if (activity.Activity.Name.includes("BCAR")) {
+                args[4] ??= {}; // null | { image?: string }
+                args[4].image = CustomImages.get(activity.Activity.Name);
+            }
+            return next(args);
+        });
+    }
 
     // -- Tail Wag
     var wagActivity = {

--- a/script/bcarBeta.js
+++ b/script/bcarBeta.js
@@ -4844,16 +4844,28 @@ CommandCombine([
     });
 
     // -- Support for repointing or adding custom image thumbnails to activities
-    modApi.hookFunction("DrawImageResize", 1, (args, next) => {
-        var path = args[0];
-        if (!!path && (typeof path === 'string') && path.indexOf("BCAR_") > -1) {
-            var activityName = path.substring(path.indexOf("BCAR_"));
-            activityName = activityName.substring(0, activityName.indexOf(".png"))
-            if (CustomImages.has(activityName))
-                args[0] = CustomImages.get(activityName);
-        }
-        return next(args);
-    });
+    if (GameVersion === "R110") {
+        modApi.hookFunction("DrawImageResize", 1, (args, next) => {
+            var path = args[0];
+            if (!!path && (typeof path === 'string') && path.indexOf("BCAR_") > -1) {
+                var activityName = path.substring(path.indexOf("BCAR_"));
+                activityName = activityName.substring(0, activityName.indexOf(".png"))
+                if (CustomImages.has(activityName))
+                    args[0] = CustomImages.get(activityName);
+            }
+            return next(args);
+        });
+    } else { // R111
+        modApi.hookFunction("ElementButton.CreateForActivity", 0, (args, next) => {
+            /** @type {ItemActivity} */
+            const activity = args[1];
+            if (activity.Activity.Name.includes("BCAR")) {
+                args[4] ??= {}; // null | { image?: string }
+                args[4].image = CustomImages.get(activity.Activity.Name);
+            }
+            return next(args);
+        });
+    }
 
     // -- Tail Wag
     var wagActivity = {


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5278](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5278)

Above-mentioned PR overhauls the UI of a number of dialog menu modes (including the `activites` mode) for R111, switching from a canvas- to DOM-based UI. Consequently, custom activities will now have to hook into `ElementButton.CreateForActivity()` in order to set their custom button images, a change which is thus introduced herein.

Includes changes both suitable for the beta-period and full R111 release.

